### PR TITLE
Add RanDU hard reboot test case with helper functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
-	github.com/openshift-kni/eco-goinfra v0.0.0-20230926141153-ce33aad75e9d
+	github.com/openshift-kni/eco-goinfra v0.0.0-20231006185241-4e996b952657
 	github.com/openshift-kni/k8sreporter v1.0.4
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.27.1

--- a/go.sum
+++ b/go.sum
@@ -897,8 +897,8 @@ github.com/opencontainers/image-spec v1.1.0-rc3 h1:fzg1mXZFj8YdPeNkRXMg+zb88BFV0
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/openshift-kni/eco-goinfra v0.0.0-20230914145933-299b0bbaa833 h1:JP675DUOSDFFIHC6whRnqsw6vOqdjhF/WrxhzhqY2TI=
-github.com/openshift-kni/eco-goinfra v0.0.0-20230914145933-299b0bbaa833/go.mod h1:St1dFSs548xWjXmSlmcNzmdt6WYD2e6QCMXJqu9RrsA=
+github.com/openshift-kni/eco-goinfra v0.0.0-20231006185241-4e996b952657 h1:ltQWVWguFhUWwWKIA6n6xVitLa+Oi4ol8/MBtCPgSgs=
+github.com/openshift-kni/eco-goinfra v0.0.0-20231006185241-4e996b952657/go.mod h1:L+XSM+b6pjDTMzK80YsxK+vgX8quKlj2f/eaX6AvLcY=
 github.com/openshift-kni/k8sreporter v1.0.4 h1:jEwX6Pqei60kO1U0JLo+ePjQaP7DNn/M6d63KCS2tS0=
 github.com/openshift-kni/k8sreporter v1.0.4/go.mod h1:fg8HI9yxiKAi6UzR6NTtrmQmA2WKzUqmkRUHwQ1+Bj8=
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=

--- a/tests/internal/config/config.go
+++ b/tests/internal/config/config.go
@@ -33,6 +33,7 @@ type GeneralConfig struct {
 	WorkerLabelMap         map[string]string
 	ControlPlaneLabelMap   map[string]string
 	SriovOperatorNamespace string `yaml:"sriov_operator_namespace" envconfig:"ECO_SYSTEM_TESTS_SRIOV_OPERATOR_NAMESPACE"`
+	IpmiToolImage          string `yaml:"ipmitool_image" envconfig:"ECO_SYSTEM_TESTS_IPMITOOL_IMAGE"`
 }
 
 // NewConfig returns instance of GeneralConfig config type.

--- a/tests/internal/config/default.yaml
+++ b/tests/internal/config/default.yaml
@@ -12,4 +12,5 @@ polarion_tc_prefix: "OCP-"
 mco_namespace: "openshift-machine-config-operator"
 mco_config_daemon_name: "machine-config-daemon"
 sriov_operator_namespace: openshift-sriov-network-operator
+ipmitool_image: 'quay.io/ocp-edge-qe/ipmitool@sha256:e843f0b3f20224d549b1b74c99f8e26da7877eea8053c8ad75e5dd5e087b9a65'
 ...

--- a/tests/internal/params/vars.go
+++ b/tests/internal/params/vars.go
@@ -1,0 +1,13 @@
+package systemtestsparams
+
+var (
+	// HardRebootDeploymentName represents the deployment name used in hard reboot test.
+	HardRebootDeploymentName = "ipmitoool-hardreboot"
+	// PrivilegedNSLabels represents privileged labels.
+	PrivilegedNSLabels = map[string]string{
+		"pod-security.kubernetes.io/audit":               "privileged",
+		"pod-security.kubernetes.io/enforce":             "privileged",
+		"pod-security.kubernetes.io/warn":                "privileged",
+		"security.openshift.io/scc.podSecurityLabelSync": "false",
+	}
+)

--- a/tests/internal/reboot/reboot.go
+++ b/tests/internal/reboot/reboot.go
@@ -1,7 +1,19 @@
 package reboot
 
 import (
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/deployment"
+	"github.com/openshift-kni/eco-goinfra/pkg/pod"
 	"github.com/openshift-kni/eco-gosystem/tests/internal/cmd"
+	. "github.com/openshift-kni/eco-gosystem/tests/internal/inittools"
+	systemtestsparams "github.com/openshift-kni/eco-gosystem/tests/internal/params"
+	systemtestsscc "github.com/openshift-kni/eco-gosystem/tests/internal/scc"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // SoftRebootNode executes systemctl reboot on a node.
@@ -9,6 +21,75 @@ func SoftRebootNode(nodeName string) error {
 	cmdToExec := []string{"chroot", "/rootfs", "systemctl", "reboot"}
 
 	_, err := cmd.ExecCmd(cmdToExec, nodeName)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// HardRebootNode executes ipmitool chassis power cycle on a node.
+func HardRebootNode(nodeName string, nsName string) error {
+	err := systemtestsscc.AddPrivilegedSCCtoDefaultSA(nsName)
+	if err != nil {
+		return err
+	}
+
+	deployContainer := pod.NewContainerBuilder(systemtestsparams.HardRebootDeploymentName,
+		GeneralConfig.IpmiToolImage, []string{"sleep", "86400"})
+
+	trueVar := true
+	deployContainer = deployContainer.WithSecurityContext(&v1.SecurityContext{Privileged: &trueVar})
+
+	deployContainerCfg, err := deployContainer.GetContainerCfg()
+	if err != nil {
+		return err
+	}
+
+	createDeploy := deployment.NewBuilder(APIClient, systemtestsparams.HardRebootDeploymentName, nsName,
+		map[string]string{"test": "hardreboot"}, deployContainerCfg)
+	createDeploy = createDeploy.WithNodeSelector(map[string]string{"kubernetes.io/hostname": nodeName})
+
+	_, err = createDeploy.CreateAndWaitUntilReady(300 * time.Second)
+	if err != nil {
+		return err
+	}
+
+	listOptions := metav1.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName}).String(),
+		LabelSelector: labels.SelectorFromSet(labels.Set{"test": "hardreboot"}).String(),
+	}
+	ipmiPods, err := pod.List(APIClient, nsName, listOptions)
+
+	if err != nil {
+		return err
+	}
+
+	// pull openshift apiserver deployment object to wait for after the node reboot.
+	openshiftAPIDeploy, err := deployment.Pull(APIClient, "apiserver", "openshift-apiserver")
+
+	if err != nil {
+		return err
+	}
+
+	cmdToExec := []string{"ipmitool", "chassis", "power", "cycle"}
+
+	glog.V(90).Infof("Exec cmd %v on pod %s", cmdToExec, ipmiPods[0].Definition.Name)
+	_, err = ipmiPods[0].ExecCommand(cmdToExec)
+
+	if err != nil {
+		return err
+	}
+
+	// wait for the openshift apiserver deployment to be available
+	err = openshiftAPIDeploy.WaitUntilCondition("Available", 5*time.Minute)
+
+	if err != nil {
+		return err
+	}
+
+	err = createDeploy.DeleteAndWait(2 * time.Minute)
 
 	if err != nil {
 		return err

--- a/tests/internal/scc/scc.go
+++ b/tests/internal/scc/scc.go
@@ -1,0 +1,34 @@
+package systemtestsscc
+
+import (
+	"fmt"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/scc"
+	. "github.com/openshift-kni/eco-gosystem/tests/internal/inittools"
+)
+
+// AddPrivilegedSCCtoDefaultSA adds default service account in a namespace to the privileged SCC.
+func AddPrivilegedSCCtoDefaultSA(nsName string) error {
+	privSCCRequired := true
+	sccUser := fmt.Sprintf("system:serviceaccount:%s:default", nsName)
+	privSCC, err := scc.Pull(APIClient, "privileged")
+
+	if err != nil {
+		return err
+	}
+
+	for _, usr := range privSCC.Object.Users {
+		if usr == sccUser {
+			privSCCRequired = false
+		}
+	}
+
+	if privSCCRequired {
+		_, err = privSCC.WithUsers([]string{sccUser}).Update()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/tests/ran-du/internal/randuconfig/config.go
+++ b/tests/ran-du/internal/randuconfig/config.go
@@ -25,6 +25,8 @@ type RanDuConfig struct {
 		CreateShellCmd string `yaml:"create_shell_cmd" envconfig:"ECO_RANDU_TESTWORKLOAD_CREATE_SHELLCMD"`
 	} `yaml:"randu_test_workload"`
 	SoftRebootIterations string `yaml:"soft_reboot_iterations" envconfig:"ECO_RANDU_SOFT_REBOOT_ITERATIONS"`
+	HardRebootIterations string `yaml:"hard_reboot_iterations" envconfig:"ECO_RANDU_HARD_REBOOT_ITERATIONS"`
+	IpmiToolImage        string `yaml:"ipmitool_image" envconfig:"ECO_RANDU_IPMITOOL_IMAGE"`
 }
 
 // NewRanDuConfig returns instance of RanDuConfig config type.

--- a/tests/ran-du/internal/randuconfig/default.yaml
+++ b/tests/ran-du/internal/randuconfig/default.yaml
@@ -5,3 +5,4 @@ randu_test_workload:
     create_method: 'shell'
     create_shell_cmd: '/opt/vdu-workload-emulator/add_test-deployments.sh'
 soft_reboot_iterations: '5'
+hard_reboot_iterations: '5'

--- a/tests/ran-du/internal/randuparams/const.go
+++ b/tests/ran-du/internal/randuparams/const.go
@@ -11,4 +11,6 @@ const (
 	LabelLaunchWorkloadTestCases = "launch-workload"
 	// DefaultTimeout is the timeout used for test resources creation.
 	DefaultTimeout = 300 * time.Second
+	// TestWorkloadShellLaunchMethod is used when usin a shell script for launching the test workload.
+	TestWorkloadShellLaunchMethod = "shell"
 )

--- a/tests/ran-du/internal/randuparams/randuvars.go
+++ b/tests/ran-du/internal/randuparams/randuvars.go
@@ -19,4 +19,7 @@ var (
 	ReporterCRDsToDump = []k8sreporter.CRData{
 		{Cr: &v1.PodList{}},
 	}
+
+	// TestNamespaceName is used for defining the namespace name where test resources are created.
+	TestNamespaceName = "ran-du-system-tests"
 )

--- a/tests/ran-du/ran_du_suite_test.go
+++ b/tests/ran-du/ran_du_suite_test.go
@@ -1,20 +1,26 @@
 package ran_du_system_test
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/polarion"
 	"github.com/openshift-kni/eco-goinfra/pkg/reporter"
 	. "github.com/openshift-kni/eco-gosystem/tests/internal/inittools"
+	systemtestsparams "github.com/openshift-kni/eco-gosystem/tests/internal/params"
 	"github.com/openshift-kni/eco-gosystem/tests/ran-du/internal/randuparams"
 	_ "github.com/openshift-kni/eco-gosystem/tests/ran-du/tests"
 )
 
-var _, currentFile, _, _ = runtime.Caller(0)
+var (
+	_, currentFile, _, _ = runtime.Caller(0)
+	testNS               = namespace.NewBuilder(APIClient, randuparams.TestNamespaceName)
+)
 
 func TestRanDu(t *testing.T) {
 	_, reporterConfig := GinkgoConfiguration()
@@ -23,6 +29,25 @@ func TestRanDu(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "RanDU SystemTests Suite", Label(randuparams.Labels...), reporterConfig)
 }
+
+var _ = BeforeSuite(func() {
+	if !testNS.Exists() {
+		fmt.Printf("Namespace %s doesn't exist. Creating.", testNS.Definition.Name)
+
+		for key, value := range systemtestsparams.PrivilegedNSLabels {
+			testNS.WithLabel(key, value)
+		}
+
+		_, err := testNS.Create()
+		Expect(err).ToNot(HaveOccurred(), "error creating the test namespace")
+	}
+})
+
+var _ = AfterSuite(func() {
+	By("Deleting test namespace")
+	err := testNS.Delete()
+	Expect(err).ToNot(HaveOccurred(), "error deleting the test namespace")
+})
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(

--- a/tests/ran-du/tests/hard-reboot.go
+++ b/tests/ran-du/tests/hard-reboot.go
@@ -1,0 +1,151 @@
+package ran_du_system_test
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
+	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
+	"github.com/openshift-kni/eco-goinfra/pkg/pod"
+	"github.com/openshift-kni/eco-goinfra/pkg/polarion"
+	"github.com/openshift-kni/eco-gosystem/tests/internal/await"
+	"github.com/openshift-kni/eco-gosystem/tests/internal/reboot"
+	"github.com/openshift-kni/eco-gosystem/tests/internal/shell"
+	"github.com/openshift-kni/eco-gosystem/tests/internal/sriov"
+	. "github.com/openshift-kni/eco-gosystem/tests/ran-du/internal/randuinittools"
+	"github.com/openshift-kni/eco-gosystem/tests/ran-du/internal/randuparams"
+	"github.com/openshift-kni/eco-gosystem/tests/ran-du/internal/randutestworkload"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe(
+	"HardReboot",
+	Ordered,
+	ContinueOnFailure,
+	Label("HardReboot"), func() {
+		BeforeAll(func() {
+			By("Preparing workload")
+			if namespace.NewBuilder(APIClient, RanDuTestConfig.TestWorkload.Namespace).Exists() {
+				err := randutestworkload.CleanNameSpace(randuparams.DefaultTimeout, RanDuTestConfig.TestWorkload.Namespace)
+				Expect(err).ToNot(HaveOccurred(), "Failed to clean workload test namespace objects")
+			}
+
+			if RanDuTestConfig.TestWorkload.CreateMethod == randuparams.TestWorkloadShellLaunchMethod {
+				By("Launching workload using shell method")
+				_, err := shell.ExecuteCmd(RanDuTestConfig.TestWorkload.CreateShellCmd)
+				Expect(err).ToNot(HaveOccurred(), "Failed to launch workload")
+			}
+
+			By("Waiting for deployment replicas to become ready")
+			_, err := await.WaitUntilAllDeploymentsReady(APIClient, RanDuTestConfig.TestWorkload.Namespace,
+				randuparams.DefaultTimeout)
+			Expect(err).ToNot(HaveOccurred(), "error while waiting for deployment to become ready")
+
+			By("Waiting for statefulset replicas to become ready")
+			_, err = await.WaitUntilAllStatefulSetsReady(APIClient, RanDuTestConfig.TestWorkload.Namespace,
+				randuparams.DefaultTimeout)
+			Expect(err).ToNot(HaveOccurred(), "error while waiting for statefulsets to become ready")
+
+		})
+		It("Hard reboot nodes", polarion.ID("42736"), Label("HardReboot"), func() {
+			By("Retrieve nodes list")
+			nodeList, err := nodes.List(
+				APIClient,
+				metav1.ListOptions{},
+			)
+			Expect(err).ToNot(HaveOccurred(), "Error listing nodes.")
+
+			rebootIterations, err := strconv.Atoi(RanDuTestConfig.HardRebootIterations)
+			if err != nil {
+				fmt.Println(err)
+			}
+
+			for r := 0; r < rebootIterations; r++ {
+				By("Hard rebooting cluster")
+				fmt.Printf("Hard reboot iteration no. %d\n", r)
+				for _, node := range nodeList {
+					By("Reboot node")
+					fmt.Printf("Reboot node %s", node.Definition.Name)
+					err = reboot.HardRebootNode(node.Definition.Name, randuparams.TestNamespaceName)
+					Expect(err).ToNot(HaveOccurred(), "Error rebooting the nodes.")
+
+					By("Wait for two more minutes for the cluster resources to reconciliate their state")
+					time.Sleep(2 * time.Minute)
+
+					By("Remove any pods in UnexpectedAdmissionError state")
+					listOptions := metav1.ListOptions{
+						FieldSelector: "status.phase=Failed",
+					}
+					podsList, err := pod.List(APIClient, RanDuTestConfig.TestWorkload.Namespace, listOptions)
+					Expect(err).ToNot(HaveOccurred(), "could not retrieve pod list")
+
+					for _, failedPod := range podsList {
+						if failedPod.Definition.Status.Reason == "UnexpectedAdmissionError" {
+							_, err := failedPod.DeleteAndWait(60 * time.Second)
+							Expect(err).ToNot(HaveOccurred(), "could not delete pod in UnexpectedAdmissionError state")
+						}
+					}
+
+					By("Waiting for deployment replicas to become ready")
+					_, err = await.WaitUntilAllDeploymentsReady(APIClient, RanDuTestConfig.TestWorkload.Namespace,
+						randuparams.DefaultTimeout)
+					Expect(err).ToNot(HaveOccurred(), "error while waiting for deployment to become ready")
+
+					By("Waiting for statefulset replicas to become ready")
+					_, err = await.WaitUntilAllStatefulSetsReady(APIClient, RanDuTestConfig.TestWorkload.Namespace,
+						randuparams.DefaultTimeout)
+					Expect(err).ToNot(HaveOccurred(), "error while waiting for statefulsets to become ready")
+
+					By("Retrieve pod list")
+					podsList, err = pod.List(APIClient, RanDuTestConfig.TestWorkload.Namespace, metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred(), "could not retrieve pod list")
+
+					By("Retrieve sriov networks with vfio-pci driver")
+					vfioNetworks, err := sriov.ListNetworksByDeviceType(APIClient, "vfio-pci")
+					Expect(err).ToNot(HaveOccurred(), "error when retrieving sriov network using vfio-pci driver")
+
+					By("Assert devices under /dev/vfio on pod are equal or more to the pods vfio-pci network attachments\n")
+					for _, pod := range podsList {
+						networkNames, err := sriov.ExtractNetworkNames(pod.Object.Annotations["k8s.v1.cni.cncf.io/network-status"])
+						Expect(err).ToNot(HaveOccurred(), "error when retrieving pod network attachments")
+
+						podvfioDevices := 0
+
+						for _, vfioNet := range vfioNetworks {
+							for _, podNet := range networkNames {
+								if strings.Contains(podNet, pod.Definition.Namespace+"/"+vfioNet) {
+									podvfioDevices++
+								}
+							}
+						}
+
+						if podvfioDevices > 0 {
+							fmt.Printf("Check /dev/vfio on pod %s\n", pod.Definition.Name)
+							lscmd := []string{"ls", "--color=never", "/dev/vfio"}
+							cmd, err := pod.ExecCommand(lscmd)
+							Expect(err).ToNot(HaveOccurred(), "error when executing command on pod")
+
+							// retry in case the command exec returns an empty string
+							if len(cmd.String()) == 0 {
+								cmd, err = pod.ExecCommand(lscmd)
+								Expect(err).ToNot(HaveOccurred(), "error when executing command on pod")
+							}
+
+							vfioDevls := strings.Fields(strings.ReplaceAll(cmd.String(), "vfio", ""))
+							Expect(len(vfioDevls)).To(BeNumerically(">=", podvfioDevices),
+								"error: vfio devices inside pod( %s ) do not match pod %s attachments:", cmd.String(), pod.Definition.Name)
+						}
+					}
+				}
+			}
+		})
+		AfterAll(func() {
+			By("Cleaning up test workload resources")
+			err := randutestworkload.CleanNameSpace(randuparams.DefaultTimeout, RanDuTestConfig.TestWorkload.Namespace)
+			Expect(err).ToNot(HaveOccurred(), "Failed to clean workload test namespace objects")
+		})
+	})

--- a/vendor/github.com/openshift-kni/eco-goinfra/pkg/assisted/agentclusterinstall.go
+++ b/vendor/github.com/openshift-kni/eco-goinfra/pkg/assisted/agentclusterinstall.go
@@ -27,12 +27,6 @@ type AgentClusterInstallBuilder struct {
 	apiClient  *clients.Settings
 }
 
-// agentClusterInstallCondition provides a struct for tracking a specific agentclusterinstall condition.
-type agentClusterInstallCondition struct {
-	v1.ClusterInstallCondition
-	index int
-}
-
 // AgentClusterInstallAdditionalOptions additional options for AgentClusterInstall object.
 type AgentClusterInstallAdditionalOptions func(builder *AgentClusterInstallBuilder) (*AgentClusterInstallBuilder, error)
 
@@ -376,165 +370,43 @@ func (builder *AgentClusterInstallBuilder) WithOptions(
 	return builder
 }
 
-// GetCondition creates and returns a new agentClusterInstallCondition based on the condition type provided.
-func (builder *AgentClusterInstallBuilder) GetCondition(conditionType string) (*agentClusterInstallCondition, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	glog.V(100).Infof("Getting condition %s from agentclusterinstall %s", conditionType, builder.Definition.Name)
-
-	if !builder.Exists() {
-		glog.V(100).Infof("Getting agentclusterinstallcondtion from non-existent agentclusterinstall")
-
-		return nil, fmt.Errorf("cannot get conditions from non-existent agentclusterinstall")
-	}
-
-	err := builder.waitForConditions(retryInterval * 2)
-	if err != nil {
-		return nil, err
-	}
-
-	for index, condition := range builder.Object.Status.Conditions {
-		if conditionType == condition.Type {
-			return newagentClusterInstallCondition(conditionType, index, condition)
-		}
-	}
-
-	return nil, fmt.Errorf("condition '%s' does not exist within agentclusterinstall conditions", conditionType)
-}
-
-// UpdateCondition updates the agentClusterInstallCondition fields with the current state of the condition.
-func (builder *AgentClusterInstallBuilder) UpdateCondition(
-	condition *agentClusterInstallCondition) (*agentClusterInstallCondition, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	if !builder.Exists() {
-		glog.V(100).Infof("Agentclusterinstall %s does not exist on cluster", builder.Definition.Name)
-
-		return nil, fmt.Errorf("cannot update condition on non-existent agentclusterinstall")
-	}
-
-	if condition == nil {
-		glog.V(100).Infof("cannot update undefined condition agentClusterInstallCondition")
-
-		return nil, fmt.Errorf("cannot update condition on non-existent agentclusterinstallconditon")
-	}
-
-	glog.V(100).Infof("Updating condition %s in agentclusterinstall %s", condition.Type, builder.Definition.Name)
-
-	err := builder.waitForConditions(retryInterval * 2)
-	if err != nil {
-		return nil, err
-	}
-
-	agentClusterInstall, err := builder.Get()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(agentClusterInstall.Status.Conditions) < condition.index+1 || condition.index < 0 {
-		glog.V(100).Infof("agentClusterInstallCondition index is out of bounds")
-
-		return nil, fmt.Errorf("cannot find condition: agentClusterInstallCondition index is out of bounds")
-	}
-
-	condition.ClusterInstallCondition = agentClusterInstall.Status.Conditions[condition.index]
-
-	return condition, nil
-}
-
 // WaitForConditionMessage waits the specified timeout for the given condition to report the specified message.
 func (builder *AgentClusterInstallBuilder) WaitForConditionMessage(
-	condition *agentClusterInstallCondition,
-	message string,
-	timeout time.Duration) (*agentClusterInstallCondition, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	if condition == nil {
-		return nil, fmt.Errorf("cannot wait for undefined condition message")
-	}
-
-	glog.V(100).Infof("Waiting for message '%s' on condition %s in agentclusterinstall %s",
-		message, condition.Type, builder.Definition.Name)
-
-	// Polls every retryInterval to determine if agentclusterinstall validation has desired status.
-	err := wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
-		_, err := builder.UpdateCondition(condition)
+	conditionType, message string, timeout time.Duration) error {
+	return wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
+		condition, err := builder.getCondition(conditionType)
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 
-		return condition.Message == message, err
+		return condition.Message == message, nil
 	})
-
-	if err == nil {
-		return condition, nil
-	}
-
-	return nil, err
 }
 
 // WaitForConditionStatus waits the specified timeout for the given condition to report the specified status.
 func (builder *AgentClusterInstallBuilder) WaitForConditionStatus(
-	condition *agentClusterInstallCondition,
-	status string,
-	timeout time.Duration) (*agentClusterInstallCondition, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	if condition == nil {
-		return nil, fmt.Errorf("cannot wait for undefined condition status")
-	}
-
-	glog.V(100).Infof("Waiting for status '%s' on condition %s in agentclusterinstall %s",
-		status, condition.Type, builder.Definition.Name)
-
-	// Polls every retryInterval to determine if agentclusterinstall validation has desired status.
-	err := wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
-		_, err := builder.UpdateCondition(condition)
+	conditionType string, status coreV1.ConditionStatus, timeout time.Duration) error {
+	return wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
+		condition, err := builder.getCondition(conditionType)
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 
-		return string(condition.Status) == status, err
+		return condition.Status == status, nil
 	})
-
-	return condition, err
 }
 
 // WaitForConditionReason waits the specified timeout for the given condition to report the specified reason.
 func (builder *AgentClusterInstallBuilder) WaitForConditionReason(
-	condition *agentClusterInstallCondition,
-	reason string,
-	timeout time.Duration) (*agentClusterInstallCondition, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	if condition == nil {
-		return nil, fmt.Errorf("cannot wait for undefined condition reason")
-	}
-
-	glog.V(100).Infof("Waiting for reason '%s' on condition %s in agentclusterinstall %s",
-		reason, condition.Type, builder.Definition.Name)
-
-	// Polls every retryInterval to determine if agentclusterinstall validation has desired status.
-	err := wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
-		_, err := builder.UpdateCondition(condition)
+	conditionType, reason string, timeout time.Duration) error {
+	return wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
+		condition, err := builder.getCondition(conditionType)
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 
-		return condition.Reason == reason, err
+		return condition.Reason == reason, nil
 	})
-
-	return condition, err
 }
 
 // Get fetches the defined agentclusterinstall from the cluster.
@@ -660,6 +532,10 @@ func (builder *AgentClusterInstallBuilder) Update(force bool) (*AgentClusterInst
 		}
 	}
 
+	if err == nil {
+		builder.Object = builder.Definition
+	}
+
 	return builder, err
 }
 
@@ -728,55 +604,38 @@ func (builder *AgentClusterInstallBuilder) Exists() bool {
 	return err == nil || !k8serrors.IsNotFound(err)
 }
 
-// newagentClusterInstallCondition creates a new instance of agentClusterInstallCondition.
-func newagentClusterInstallCondition(
-	conditionType string,
-	index int,
-	condition v1.ClusterInstallCondition) (*agentClusterInstallCondition, error) {
-	glog.V(100).Infof(
-		"Initializing new agentClusterInstallCondition structure with the following params: "+
-			"conditionType: %s, index: %d, condition: %v",
-		conditionType, index, condition)
-
-	if conditionType == "" {
-		glog.V(100).Infof("The conditionType is empty")
-
-		return nil, fmt.Errorf("cannot create agentClusterInstallCondition without a condition type")
-	}
-
-	if index < 0 {
-		return nil, fmt.Errorf("cannot create agentClusterInstallCondition with an index less than 0")
-	}
-
-	return &agentClusterInstallCondition{
-		ClusterInstallCondition: condition,
-		index:                   index,
-	}, nil
-}
-
-// waitForConditions waits the specified timeout for conditions to be available on the agentclusterinstall.
-func (builder *AgentClusterInstallBuilder) waitForConditions(
-	timeout time.Duration) error {
+// getCondition returns the agentclusterinstall condition discovered based on specified conditionType.
+func (builder *AgentClusterInstallBuilder) getCondition(conditionType string) (*v1.ClusterInstallCondition, error) {
 	if valid, err := builder.validate(); !valid {
-		return err
+		return nil, err
 	}
 
-	if !builder.Exists() {
-		return fmt.Errorf("cannot get conditions from undefined agentclusterinstall")
-	}
-	// Polls every retryInterval to determine if agentclusterinstall conditions are available.
-	var err error
-	err = wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
-		builder.Object, err = builder.Get()
-
-		if err != nil {
-			return false, nil
+	// wait for agentclusterinstall conditions to be published to the agentclusterinstall status
+	err := wait.PollImmediate(time.Second, time.Second*5, func() (bool, error) {
+		if !builder.Exists() {
+			return false, fmt.Errorf("agentclusterinstall object %s doesn't exist in namespace %s",
+				builder.Definition.Name, builder.Definition.Namespace)
 		}
 
-		return builder.Object.Status.Conditions != nil, err
+		if len(builder.Object.Status.Conditions) > 0 {
+			return true, nil
+		}
+
+		return false, nil
 	})
 
-	return err
+	if err != nil {
+		return nil, fmt.Errorf("error while waiting for conditions to be published: %w", err)
+	}
+
+	for _, condition := range builder.Object.Status.Conditions {
+		if condition.Type == conditionType {
+			return &condition, nil
+		}
+	}
+
+	return nil, fmt.Errorf("agentclusterinstall %s in namespace %s did not contain condition %s",
+		builder.Definition.Name, builder.Definition.Namespace, conditionType)
 }
 
 // validate will check that the builder and builder definition are properly initialized before

--- a/vendor/github.com/openshift-kni/eco-goinfra/pkg/assisted/agentserviceconfig.go
+++ b/vendor/github.com/openshift-kni/eco-goinfra/pkg/assisted/agentserviceconfig.go
@@ -381,6 +381,10 @@ func (builder *AgentServiceConfigBuilder) Update(force bool) (*AgentServiceConfi
 		}
 	}
 
+	if err == nil {
+		builder.Object = builder.Definition
+	}
+
 	return builder, err
 }
 

--- a/vendor/github.com/openshift-kni/eco-goinfra/pkg/olm/installplan.go
+++ b/vendor/github.com/openshift-kni/eco-goinfra/pkg/olm/installplan.go
@@ -1,0 +1,163 @@
+package olm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/msg"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// InstallPlanBuilder provides a struct for installplan object from the cluster and an installplan definition.
+type InstallPlanBuilder struct {
+	// Installplan definition, used to create the installplan object.
+	Definition *v1alpha1.InstallPlan
+	// Created installplan object.
+	Object *v1alpha1.InstallPlan
+	// Used in functions that define or mutate installplan definition. errorMsg is processed
+	// before the installplan object is created
+	errorMsg string
+	// api client to interact with the cluster.
+	apiClient *clients.Settings
+}
+
+// NewInstallPlanBuilder creates new instance of InstallPlanBuilder.
+func NewInstallPlanBuilder(apiClient *clients.Settings, name, nsname string) *InstallPlanBuilder {
+	glog.V(100).Infof("Initializing new %s installplan structure", name)
+
+	builder := InstallPlanBuilder{
+		apiClient: apiClient,
+		Definition: &v1alpha1.InstallPlan{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      name,
+				Namespace: nsname,
+			},
+		},
+	}
+
+	if name == "" {
+		glog.V(100).Infof("The name of the installplan is empty")
+
+		builder.errorMsg = "installplan 'name' cannot be empty"
+	}
+
+	if nsname == "" {
+		glog.V(100).Infof("The nsname of the installplan is empty")
+
+		builder.errorMsg = "installplan 'nsname' cannot be empty"
+	}
+
+	return &builder
+}
+
+// Create makes an InstallPlanBuilder in cluster and stores the created object in struct.
+func (builder *InstallPlanBuilder) Create() (*InstallPlanBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	glog.V(100).Infof("Creating the InstallPlan %s in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	var err error
+	if !builder.Exists() {
+		builder.Object, err = builder.apiClient.InstallPlans(builder.Definition.Namespace).Create(context.Background(),
+			builder.Definition, metaV1.CreateOptions{})
+	}
+
+	return builder, err
+}
+
+// Exists checks whether the given installplan exists.
+func (builder *InstallPlanBuilder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	glog.V(100).Infof("Checking if installplan %s exists in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	var err error
+	builder.Object, err = builder.apiClient.InstallPlans(builder.Definition.Namespace).Get(
+		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// Delete removes an installplan.
+func (builder *InstallPlanBuilder) Delete() error {
+	if valid, err := builder.validate(); !valid {
+		return err
+	}
+
+	glog.V(100).Infof("Deleting installplan %s in namespace %s", builder.Definition.Name,
+		builder.Definition.Namespace)
+
+	if !builder.Exists() {
+		return nil
+	}
+
+	err := builder.apiClient.InstallPlans(builder.Definition.Namespace).Delete(context.TODO(),
+		builder.Object.Name, metaV1.DeleteOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	builder.Object = nil
+
+	return err
+}
+
+// Update modifies the existing InstallPlanBuilder with the InstallPlan definition in InstallPlanBuilder.
+func (builder *InstallPlanBuilder) Update() (*InstallPlanBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	glog.V(100).Infof("Updating installPlan %s in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	var err error
+	builder.Object, err = builder.apiClient.InstallPlans(builder.Definition.Namespace).Update(
+		context.TODO(), builder.Definition, metaV1.UpdateOptions{})
+
+	return builder, err
+}
+
+// validate will check that the builder and builder definition are properly initialized before
+// accessing any member fields.
+func (builder *InstallPlanBuilder) validate() (bool, error) {
+	resourceCRD := "installplan"
+
+	if builder == nil {
+		glog.V(100).Infof("The builder %s is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		glog.V(100).Infof("The %s is undefined", resourceCRD)
+
+		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+	}
+
+	if builder.apiClient == nil {
+		glog.V(100).Infof("The builder %s apiclient is nil", resourceCRD)
+
+		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		glog.V(100).Infof("The builder %s has error message: %w", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf(builder.errorMsg)
+	}
+
+	return true, nil
+}

--- a/vendor/github.com/openshift-kni/eco-goinfra/pkg/olm/installplanlist.go
+++ b/vendor/github.com/openshift-kni/eco-goinfra/pkg/olm/installplanlist.go
@@ -1,0 +1,47 @@
+package olm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ListInstallPlan returns a list of installplans found for specific namespace.
+func ListInstallPlan(apiClient *clients.Settings, nsname string) ([]*InstallPlanBuilder, error) {
+	if nsname == "" {
+		glog.V(100).Info("The nsname of the installplan is empty")
+
+		return nil, fmt.Errorf("the nsname of the installplan is empty")
+	}
+
+	installPlanList, err := apiClient.InstallPlans(nsname).List(context.Background(), v1.ListOptions{})
+
+	if err != nil {
+		glog.V(100).Infof("Failed to list all installplan in namespace %s due to %s",
+			nsname, err.Error())
+
+		return nil, err
+	}
+
+	var installPlanObjects []*InstallPlanBuilder
+
+	for _, foundCsv := range installPlanList.Items {
+		copiedCsv := foundCsv
+		csvBuilder := &InstallPlanBuilder{
+			apiClient:  apiClient,
+			Object:     &copiedCsv,
+			Definition: &copiedCsv,
+		}
+
+		installPlanObjects = append(installPlanObjects, csvBuilder)
+	}
+
+	if len(installPlanObjects) == 0 {
+		return nil, fmt.Errorf("installplan not found in namespace %s", nsname)
+	}
+
+	return installPlanObjects, nil
+}

--- a/vendor/github.com/openshift-kni/eco-goinfra/pkg/pod/pod.go
+++ b/vendor/github.com/openshift-kni/eco-goinfra/pkg/pod/pod.go
@@ -952,6 +952,33 @@ func (builder *Builder) GetLog(logStartTime time.Duration, containerName string)
 	return buf.String(), nil
 }
 
+// GetFullLog connects to a pod and fetches the full log since pod creation.
+func (builder *Builder) GetFullLog(containerName string) (string, error) {
+	if valid, err := builder.validate(); !valid {
+		return "", err
+	}
+
+	logStream, err := builder.apiClient.Pods(builder.Definition.Namespace).GetLogs(builder.Definition.Name,
+		&v1.PodLogOptions{Container: containerName}).Stream(context.Background())
+
+	if err != nil {
+		return "", err
+	}
+
+	defer func() {
+		_ = logStream.Close()
+	}()
+
+	logBuffer := new(bytes.Buffer)
+	_, err = io.Copy(logBuffer, logStream)
+
+	if err != nil {
+		return "", err
+	}
+
+	return logBuffer.String(), nil
+}
+
 // GetGVR returns pod's GroupVersionResource which could be used for Clean function.
 func GetGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}

--- a/vendor/github.com/openshift-kni/eco-goinfra/pkg/scc/scc.go
+++ b/vendor/github.com/openshift-kni/eco-goinfra/pkg/scc/scc.go
@@ -1,0 +1,596 @@
+package scc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/msg"
+	securityV1 "github.com/openshift/api/security/v1"
+	coreV1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Builder provides struct for SecurityContextConstraints object containing connection
+// to the cluster SecurityContextConstraints definition.
+type Builder struct {
+	// SecurityContextConstraints definition. Used to create SecurityContextConstraints object
+	Definition *securityV1.SecurityContextConstraints
+	// Created SecurityContextConstraints object
+	Object *securityV1.SecurityContextConstraints
+	// Used in functions that define or mutate SecurityContextConstraints definition. errorMsg is processed
+	// before the SecurityContextConstraints object is created
+	errorMsg  string
+	apiClient *clients.Settings
+}
+
+// SecurityContextConstraintsAdditionalOptions additional options for SecurityContextConstraints object.
+type SecurityContextConstraintsAdditionalOptions func(builder *Builder) (*Builder, error)
+
+// NewBuilder creates new instance of Builder.
+func NewBuilder(apiClient *clients.Settings, name, runAsUser, selinuxContext string) *Builder {
+	glog.V(100).Infof(
+		"Initializing new SecurityContextConstraints structure with the following params: "+
+			"name: %s, runAsUser type: %s, selinuxContext type: %s", name, runAsUser, selinuxContext)
+
+	builder := Builder{
+		apiClient: apiClient,
+		Definition: &securityV1.SecurityContextConstraints{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name: name,
+			},
+			RunAsUser: securityV1.RunAsUserStrategyOptions{
+				Type: securityV1.RunAsUserStrategyType(runAsUser),
+			},
+			SELinuxContext: securityV1.SELinuxContextStrategyOptions{
+				Type: securityV1.SELinuxContextStrategyType(selinuxContext),
+			},
+		},
+	}
+
+	if name == "" {
+		glog.V(100).Infof("The name of the SecurityContextConstraints is empty")
+
+		builder.errorMsg = "SecurityContextConstraints 'name' cannot be empty"
+	}
+
+	if runAsUser == "" {
+		glog.V(100).Infof("The runAsUser of the SecurityContextConstraints is empty")
+
+		builder.errorMsg = "SecurityContextConstraints 'runAsUser' cannot be empty"
+	}
+
+	if selinuxContext == "" {
+		glog.V(100).Infof("The selinuxContext of the SecurityContextConstraints is empty")
+
+		builder.errorMsg = "SecurityContextConstraints 'selinuxContext' cannot be empty"
+	}
+
+	return &builder
+}
+
+// Pull pulls existing SecurityContextConstraints from cluster.
+func Pull(apiClient *clients.Settings, name string) (*Builder, error) {
+	glog.V(100).Infof("Pulling existing SecurityContextConstraints object name %s from cluster", name)
+
+	builder := Builder{
+		apiClient: apiClient,
+		Definition: &securityV1.SecurityContextConstraints{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name: name,
+			},
+		},
+	}
+
+	if name == "" {
+		glog.V(100).Infof("The name of the SecurityContextConstraints is empty")
+
+		builder.errorMsg = "SecurityContextConstraints 'name' cannot be empty"
+	}
+
+	if !builder.Exists() {
+		return nil, fmt.Errorf("SecurityContextConstraints object %s doesn't exist", name)
+	}
+
+	builder.Definition = builder.Object
+
+	return &builder, nil
+}
+
+// WithPrivilegedContainer adds bool flag to the allowPrivilegedContainer of SecurityContextConstraints.
+func (builder *Builder) WithPrivilegedContainer(allowPrivileged bool) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		" AllowPrivilegedContainer: %t flag", builder.Definition.Name, allowPrivileged)
+
+	builder.Definition.AllowPrivilegedContainer = allowPrivileged
+
+	return builder
+}
+
+// WithPrivilegedEscalation adds bool flag to the allowPrivilegeEscalation of SecurityContextConstraints.
+func (builder *Builder) WithPrivilegedEscalation(allowPrivilegedEscalation bool) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		" allowPrivilegedEscalation: %t flag", builder.Definition.Name, allowPrivilegedEscalation)
+
+	builder.Definition.DefaultAllowPrivilegeEscalation = &allowPrivilegedEscalation
+
+	return builder
+}
+
+// WithHostDirVolumePlugin adds bool flag to the allowHostDirVolumePlugin of SecurityContextConstraints.
+func (builder *Builder) WithHostDirVolumePlugin(allowPlugin bool) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		" allowHostDirVolumePlugin: %t flag", builder.Definition.Name, allowPlugin)
+
+	builder.Definition.AllowHostDirVolumePlugin = allowPlugin
+
+	return builder
+}
+
+// WithHostIPC adds bool flag to the allowHostIPC of SecurityContextConstraints.
+func (builder *Builder) WithHostIPC(allowHostIPC bool) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		" allowHostIPC: %t flag", builder.Definition.Name, allowHostIPC)
+
+	builder.Definition.AllowHostIPC = allowHostIPC
+
+	return builder
+}
+
+// WithHostNetwork adds bool flag to the allowHostNetwork of SecurityContextConstraints.
+func (builder *Builder) WithHostNetwork(allowHostNetwork bool) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		" allowHostNetwork: %t flag", builder.Definition.Name, allowHostNetwork)
+
+	builder.Definition.AllowHostNetwork = allowHostNetwork
+
+	return builder
+}
+
+// WithHostPID adds bool flag to the allowHostPID of SecurityContextConstraints.
+func (builder *Builder) WithHostPID(allowHostPID bool) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		" allowHostPID: %t flag", builder.Definition.Name, allowHostPID)
+
+	builder.Definition.AllowHostPID = allowHostPID
+
+	return builder
+}
+
+// WithHostPorts adds bool flag to the allowHostPorts of SecurityContextConstraints.
+func (builder *Builder) WithHostPorts(allowHostPorts bool) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		" allowHostPorts: %t flag", builder.Definition.Name, allowHostPorts)
+
+	builder.Definition.AllowHostPorts = allowHostPorts
+
+	return builder
+}
+
+// WithReadOnlyRootFilesystem adds bool flag to the readOnlyRootFilesystem of SecurityContextConstraints.
+func (builder *Builder) WithReadOnlyRootFilesystem(readOnlyRootFilesystem bool) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		" readOnlyRootFilesystem: %t flag", builder.Definition.Name, readOnlyRootFilesystem)
+
+	builder.Definition.ReadOnlyRootFilesystem = readOnlyRootFilesystem
+
+	return builder
+}
+
+// WithDropCapabilities adds list of drop capabilities to SecurityContextConstraints.
+func (builder *Builder) WithDropCapabilities(requiredDropCapabilities []coreV1.Capability) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		"requiredDropCapabilities: %v", builder.Definition.Name, requiredDropCapabilities)
+
+	if len(requiredDropCapabilities) == 0 {
+		glog.V(100).Infof("SecurityContextConstraints 'requiredDropCapabilities' argument cannot be empty")
+
+		builder.errorMsg = "SecurityContextConstraints 'requiredDropCapabilities' cannot be empty list"
+
+		return builder
+	}
+
+	if builder.Definition.RequiredDropCapabilities == nil {
+		builder.Definition.RequiredDropCapabilities = requiredDropCapabilities
+
+		return builder
+	}
+
+	builder.Definition.RequiredDropCapabilities = append(
+		builder.Definition.RequiredDropCapabilities, requiredDropCapabilities...)
+
+	return builder
+}
+
+// WithAllowCapabilities adds list of allow capabilities to SecurityContextConstraints.
+func (builder *Builder) WithAllowCapabilities(allowCapabilities []coreV1.Capability) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		"allowCapabilities: %v", builder.Definition.Name, allowCapabilities)
+
+	if len(allowCapabilities) == 0 {
+		glog.V(100).Infof("SecurityContextConstraints 'allowCapabilities' argument cannot be empty")
+
+		builder.errorMsg = "SecurityContextConstraints 'allowCapabilities' cannot be empty list"
+
+		return builder
+	}
+
+	if builder.Definition.AllowedCapabilities == nil {
+		builder.Definition.AllowedCapabilities = allowCapabilities
+
+		return builder
+	}
+
+	builder.Definition.AllowedCapabilities = append(builder.Definition.AllowedCapabilities, allowCapabilities...)
+
+	return builder
+}
+
+// WithDefaultAddCapabilities adds list of defaultAddCapabilities to SecurityContextConstraints.
+func (builder *Builder) WithDefaultAddCapabilities(defaultAddCapabilities []coreV1.Capability) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		"defaultAddCapabilities: %v", builder.Definition.Name, defaultAddCapabilities)
+
+	if len(defaultAddCapabilities) == 0 {
+		glog.V(100).Infof("SecurityContextConstraints 'defaultAddCapabilities' argument cannot be empty")
+
+		builder.errorMsg = "SecurityContextConstraints 'defaultAddCapabilities' cannot be empty list"
+
+		return builder
+	}
+
+	if builder.Definition.DefaultAddCapabilities == nil {
+		builder.Definition.DefaultAddCapabilities = defaultAddCapabilities
+
+		return builder
+	}
+
+	builder.Definition.DefaultAddCapabilities = append(builder.Definition.DefaultAddCapabilities,
+		defaultAddCapabilities...)
+
+	return builder
+}
+
+// WithPriority adds priority to SecurityContextConstraints.
+func (builder *Builder) WithPriority(priority *int32) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		"priority: %v", builder.Definition.Name, priority)
+
+	builder.Definition.Priority = priority
+
+	return builder
+}
+
+// WithFSGroup adds fsGroup to SecurityContextConstraints.
+func (builder *Builder) WithFSGroup(fsGroup string) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		"fsGroup: %s", builder.Definition.Name, fsGroup)
+
+	if fsGroup == "" {
+		glog.V(100).Infof("SecurityContextConstraints 'fsGroup' argument cannot be empty")
+
+		builder.errorMsg = "SecurityContextConstraints 'fsGroup' cannot be empty string"
+
+		return builder
+	}
+
+	builder.Definition.FSGroup.Type = securityV1.FSGroupStrategyType(fsGroup)
+
+	return builder
+}
+
+// WithFSGroupRange adds fsGroupRange to SecurityContextConstraints.
+func (builder *Builder) WithFSGroupRange(fsGroupMin, fsGroupMax int64) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		"fsGroupRange: fsGroupMin: %d, fsGroupMax: %d", builder.Definition.Name, fsGroupMin, fsGroupMax)
+
+	if fsGroupMin > fsGroupMax {
+		glog.V(100).Infof("SecurityContextConstraints 'fsGroupMin' argument can not be greater than fsGroupMax")
+
+		builder.errorMsg = "SecurityContextConstraints 'fsGroupMin' argument can not be greater than fsGroupMax"
+
+		return builder
+	}
+
+	if builder.Definition.FSGroup.Ranges == nil {
+		builder.Definition.FSGroup.Ranges = []securityV1.IDRange{{Min: fsGroupMin, Max: fsGroupMax}}
+
+		return builder
+	}
+
+	builder.Definition.FSGroup.Ranges = append(
+		builder.Definition.FSGroup.Ranges, securityV1.IDRange{Max: fsGroupMax, Min: fsGroupMin})
+
+	return builder
+}
+
+// WithGroups adds groups to SecurityContextConstraints.
+func (builder *Builder) WithGroups(groups []string) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		"groups: %v", builder.Definition.Name, groups)
+
+	if len(groups) == 0 {
+		glog.V(100).Infof("SecurityContextConstraints 'groups' argument cannot be empty")
+
+		builder.errorMsg = "SecurityContextConstraints 'fsGroupType' cannot be empty string"
+
+		return builder
+	}
+
+	if builder.Definition.Groups == nil {
+		builder.Definition.Groups = groups
+
+		return builder
+	}
+
+	builder.Definition.Groups = append(builder.Definition.Groups, groups...)
+
+	return builder
+}
+
+// WithSeccompProfiles adds list of seccompProfiles to SecurityContextConstraints.
+func (builder *Builder) WithSeccompProfiles(seccompProfiles []string) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		"SeccompProfiles: %v", builder.Definition.Name, seccompProfiles)
+
+	if len(seccompProfiles) == 0 {
+		glog.V(100).Infof("SecurityContextConstraints 'seccompProfiles' argument cannot be empty")
+
+		builder.errorMsg = "SecurityContextConstraints 'seccompProfiles' cannot be empty list"
+
+		return builder
+	}
+
+	if builder.Definition.SeccompProfiles == nil {
+		builder.Definition.SeccompProfiles = seccompProfiles
+
+		return builder
+	}
+
+	builder.Definition.SeccompProfiles = append(builder.Definition.SeccompProfiles, seccompProfiles...)
+
+	return builder
+}
+
+// WithSupplementalGroups adds SupplementalGroups to SecurityContextConstraints.
+func (builder *Builder) WithSupplementalGroups(supplementalGroupsType string) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		"supplementalGroupsType: %s", builder.Definition.Name, supplementalGroupsType)
+
+	if supplementalGroupsType == "" {
+		glog.V(100).Infof("SecurityContextConstraints 'SupplementalGroups' argument cannot be empty")
+
+		builder.errorMsg = "SecurityContextConstraints 'SupplementalGroups' cannot be empty string"
+
+		return builder
+	}
+
+	builder.Definition.SupplementalGroups.Type = securityV1.SupplementalGroupsStrategyType(supplementalGroupsType)
+
+	return builder
+}
+
+// WithUsers adds users to SecurityContextConstraints.
+func (builder *Builder) WithUsers(users []string) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		"users: %v", builder.Definition.Name, users)
+
+	if len(users) == 0 {
+		glog.V(100).Infof("SecurityContextConstraints 'users' argument cannot be empty")
+
+		builder.errorMsg = "SecurityContextConstraints 'users' cannot be empty list"
+
+		return builder
+	}
+
+	if builder.Definition.Users == nil {
+		builder.Definition.Users = users
+
+		return builder
+	}
+
+	builder.Definition.Users = append(builder.Definition.Users, users...)
+
+	return builder
+}
+
+// WithVolumes adds list of volumes to SecurityContextConstraints.
+func (builder *Builder) WithVolumes(volumes []securityV1.FSType) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Redefining SecurityContextConstraints %s with"+
+		"volumes: %v", builder.Definition.Name, volumes)
+
+	if len(volumes) == 0 {
+		glog.V(100).Infof("SecurityContextConstraints 'volumes' argument cannot be empty")
+
+		builder.errorMsg = "SecurityContextConstraints 'volumes' cannot be empty list"
+
+		return builder
+	}
+
+	if builder.Definition.Volumes == nil {
+		builder.Definition.Volumes = volumes
+
+		return builder
+	}
+
+	builder.Definition.Volumes = append(builder.Definition.Volumes, volumes...)
+
+	return builder
+}
+
+// Create generates a SecurityContextConstraints and stores the created object in struct.
+func (builder *Builder) Create() (*Builder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	glog.V(100).Infof("Creating SecurityContextConstraints %s", builder.Definition.Name)
+
+	var err error
+	if !builder.Exists() {
+		builder.Object, err = builder.apiClient.SecurityContextConstraints().Create(
+			context.TODO(), builder.Definition, metaV1.CreateOptions{})
+	}
+
+	return builder, err
+}
+
+// Delete removes a SecurityContextConstraints.
+func (builder *Builder) Delete() error {
+	if valid, err := builder.validate(); !valid {
+		return err
+	}
+
+	glog.V(100).Infof("Removing SecurityContextConstraints %s", builder.Definition.Name)
+
+	if !builder.Exists() {
+		return nil
+	}
+
+	err := builder.apiClient.SecurityContextConstraints().Delete(
+		context.TODO(), builder.Object.Name, metaV1.DeleteOptions{})
+
+	builder.Object = nil
+
+	return err
+}
+
+// Update modifies an existing SecurityContextConstraints in the cluster.
+func (builder *Builder) Update() (*Builder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	glog.V(100).Infof("Updating SecurityContextConstraints %s ", builder.Definition.Name)
+
+	var err error
+	builder.Object, err = builder.apiClient.SecurityContextConstraints().Update(
+		context.TODO(), builder.Definition, metaV1.UpdateOptions{})
+
+	return builder, err
+}
+
+// Exists checks whether the given SecurityContextConstraints exists.
+func (builder *Builder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	glog.V(100).Infof("Checking if SecurityContextConstraints %s exists", builder.Definition.Name)
+
+	var err error
+	builder.Object, err = builder.apiClient.SecurityContextConstraints().Get(
+		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// validate will check that the builder and builder definition are properly initialized before
+// accessing any member fields.
+func (builder *Builder) validate() (bool, error) {
+	resourceCRD := "SecurityContextConstraints"
+
+	if builder == nil {
+		glog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		glog.V(100).Infof("The %s is undefined", resourceCRD)
+
+		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+	}
+
+	if builder.apiClient == nil {
+		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
+
+		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf(builder.errorMsg)
+	}
+
+	return true, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -628,7 +628,7 @@ github.com/onsi/gomega/types
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest
-# github.com/openshift-kni/eco-goinfra v0.0.0-20230926141153-ce33aad75e9d
+# github.com/openshift-kni/eco-goinfra v0.0.0-20231006185241-4e996b952657
 ## explicit; go 1.19
 github.com/openshift-kni/eco-goinfra/pkg/argocd
 github.com/openshift-kni/eco-goinfra/pkg/assisted
@@ -643,6 +643,7 @@ github.com/openshift-kni/eco-goinfra/pkg/olm
 github.com/openshift-kni/eco-goinfra/pkg/pod
 github.com/openshift-kni/eco-goinfra/pkg/polarion
 github.com/openshift-kni/eco-goinfra/pkg/reporter
+github.com/openshift-kni/eco-goinfra/pkg/scc
 github.com/openshift-kni/eco-goinfra/pkg/sriov
 github.com/openshift-kni/eco-goinfra/pkg/statefulset
 # github.com/openshift-kni/k8sreporter v1.0.4


### PR DESCRIPTION
Add a test case which hard reboots the cluster nodes by using `ipmitool chassis power cycle` command, waits for the node to recover and validates that the test applications started without issues.