### PR TITLE
Add kernel crash trigger test

### DIFF
--- a/tests/internal/reboot/reboot.go
+++ b/tests/internal/reboot/reboot.go
@@ -97,3 +97,39 @@ func HardRebootNode(nodeName string, nsName string) error {
 
 	return nil
 }
+
+// KernelCrashKdump triggers a kernel crash dump which generates a vmcore dump.
+func KernelCrashKdump(nodeName string) error {
+	// pull openshift apiserver deployment object to wait for after the node reboot.
+	openshiftAPIDeploy, err := deployment.Pull(APIClient, "apiserver", "openshift-apiserver")
+
+	if err != nil {
+		return err
+	}
+
+	cmdToExec := []string{"chroot", "/rootfs", "/bin/sh", "-c", "rm -rf /var/crash/*"}
+	glog.V(90).Infof("Remove any existing crash dumps. Exec cmd %v", cmdToExec)
+	_, err = cmd.ExecCmd(cmdToExec, nodeName)
+
+	if err != nil {
+		return err
+	}
+
+	cmdToExec = []string{"/bin/sh", "-c", "echo c > /proc/sysrq-trigger"}
+
+	glog.V(90).Infof("Trigerring kernel crash. Exec cmd %v", cmdToExec)
+	_, err = cmd.ExecCmd(cmdToExec, nodeName)
+
+	if err != nil {
+		return err
+	}
+
+	// wait for the openshift apiserver deployment to be available
+	err = openshiftAPIDeploy.WaitUntilCondition("Available", 5*time.Minute)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/ran-du/tests/kernel-crash-kdump.go
+++ b/tests/ran-du/tests/kernel-crash-kdump.go
@@ -1,0 +1,49 @@
+package ran_du_system_test
+
+import (
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
+	"github.com/openshift-kni/eco-goinfra/pkg/polarion"
+	"github.com/openshift-kni/eco-gosystem/tests/internal/cmd"
+	"github.com/openshift-kni/eco-gosystem/tests/internal/reboot"
+	. "github.com/openshift-kni/eco-gosystem/tests/ran-du/internal/randuinittools"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe(
+	"KernelCrashKdump",
+	Ordered,
+	ContinueOnFailure,
+	Label("KernelCrashKdump"), func() {
+		It("Trigger kernel crash to generate kdump vmcore", polarion.ID("56216"), Label("KernelCrashKdump"), func() {
+
+			By("Retrieve nodes list")
+			nodeList, err := nodes.List(
+				APIClient,
+				metav1.ListOptions{},
+			)
+			Expect(err).ToNot(HaveOccurred(), "Error listing nodes.")
+
+			for _, node := range nodeList {
+				By("Trigger kernel crash")
+				err = reboot.KernelCrashKdump(node.Definition.Name)
+				Expect(err).ToNot(HaveOccurred(), "Error triggering a kernel crash on the node.")
+
+				By("Wait for two more minutes for the cluster resources to reconciliate their state")
+				time.Sleep(2 * time.Minute)
+
+				By("Assert vmcore dump was generated")
+				cmdToExec := []string{"chroot", "/rootfs", "ls", "/var/crash"}
+
+				coreDumps, err := cmd.ExecCmd(cmdToExec, node.Definition.Name)
+				Expect(err).ToNot(HaveOccurred(), "could not execute command: %s", err)
+
+				Expect(len(strings.Fields(coreDumps))).To(BeNumerically(">=", 1), "error: vmcore dump was not generated")
+			}
+
+		})
+	})


### PR DESCRIPTION
Add test which triggers a kernel crash and validates a vmcore dump is generated via kdump.