### PR TITLE
Set talm suite and util functions

### DIFF
--- a/tests/gitopsztp/talm/internal/talmhelper/talmhelper.go
+++ b/tests/gitopsztp/talm/internal/talmhelper/talmhelper.go
@@ -3,10 +3,16 @@ package talmhelper
 import (
 	"errors"
 	"fmt"
+	"os"
+	"time"
 
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/pod"
 	"github.com/openshift-kni/eco-gosystem/tests/gitopsztp/internal/gitopsztphelper"
 	"github.com/openshift-kni/eco-gosystem/tests/gitopsztp/internal/gitopsztpinittools"
+	k8sErr "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/openshift-kni/eco-gosystem/tests/gitopsztp/talm/internal/talmparams"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -35,6 +41,68 @@ func VerifyTalmIsInstalled() error {
 
 		if !gitopsztphelper.IsContainerExistInPod(talmPod, talmparams.TalmContainerName) {
 			return fmt.Errorf("talm pod defined but talm container does not exist")
+		}
+	}
+
+	return nil
+}
+
+// DeleteTalmTestNamespace deletes the TALM test namespace.
+func DeleteTalmTestNamespace(allowNotFound bool) error {
+	glog.V(100).Info("Deleting talm namespace")
+
+	// Hub may be optional depending on what tests are running
+	if os.Getenv(talmparams.HubKubeEnvKey) != "" {
+		glog.V(100).Info("Deleting talm namespace on hub")
+
+		err := namespace.NewBuilder(gitopsztpinittools.HubAPIClient,
+			talmparams.TalmTestNamespace).DeleteAndWait(5 * time.Minute)
+		if err != nil {
+			if !allowNotFound || (allowNotFound && !k8sErr.IsNotFound(err)) {
+				return err
+			}
+		}
+	}
+
+	// Spoke1 is the default kubeconfig
+	if os.Getenv(talmparams.Spoke1KubeEnvKey) != "" {
+		glog.V(100).Info("Deleting talm namespace on spoke1")
+
+		err := namespace.NewBuilder(gitopsztpinittools.SpokeAPIClient,
+			talmparams.TalmTestNamespace).DeleteAndWait(5 * time.Minute)
+		if err != nil {
+			if !allowNotFound || (allowNotFound && !k8sErr.IsNotFound(err)) {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// CreateTalmTestNamespace deletes the TALM test namespace.
+func CreateTalmTestNamespace() error {
+	glog.V(100).Info("Creating talm namespace")
+
+	// Hub may be optional depending on what tests are running
+	if os.Getenv(talmparams.HubKubeEnvKey) != "" {
+		glog.V(100).Info("Creating talm namespace on hub")
+
+		_, err := namespace.NewBuilder(gitopsztpinittools.HubAPIClient,
+			talmparams.TalmTestNamespace).Create()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Spoke1 is the default kubeconfig
+	if os.Getenv(talmparams.Spoke1KubeEnvKey) != "" {
+		glog.V(100).Info("Creating talm namespace on spoke1")
+
+		_, err := namespace.NewBuilder(gitopsztpinittools.SpokeAPIClient,
+			talmparams.TalmTestNamespace).Create()
+		if err != nil {
+			return err
 		}
 	}
 

--- a/tests/gitopsztp/talm/internal/talmparams/talmparams.go
+++ b/tests/gitopsztp/talm/internal/talmparams/talmparams.go
@@ -2,6 +2,21 @@ package talmparams
 
 import (
 	"time"
+
+	"github.com/openshift-kni/k8sreporter"
+	v1 "k8s.io/api/core/v1"
+)
+
+var (
+	// ReporterNamespacesToDump tells to the reporter from where to collect logs.
+	ReporterNamespacesToDump = map[string]string{
+		TalmTestNamespace: "",
+	}
+
+	// ReporterCRDsToDump tells to the reporter what CRs to dump.
+	ReporterCRDsToDump = []k8sreporter.CRData{
+		{Cr: &v1.PodList{}},
+	}
 )
 
 // talm related vars.

--- a/tests/gitopsztp/talm/talm_suite_test.go
+++ b/tests/gitopsztp/talm/talm_suite_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift-kni/eco-gosystem/tests/gitopsztp/internal/gitopsztphelper"
 	"github.com/openshift-kni/eco-gosystem/tests/gitopsztp/talm/internal/talmhelper"
 	"github.com/openshift-kni/eco-gosystem/tests/gitopsztp/talm/internal/talmparams"
+	_ "github.com/openshift-kni/eco-gosystem/tests/gitopsztp/talm/tests"
 	. "github.com/openshift-kni/eco-gosystem/tests/internal/inittools"
 )
 

--- a/tests/gitopsztp/talm/talm_suite_test.go
+++ b/tests/gitopsztp/talm/talm_suite_test.go
@@ -6,6 +6,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/polarion"
+	"github.com/openshift-kni/eco-goinfra/pkg/reporter"
+	"github.com/openshift-kni/eco-gosystem/tests/gitopsztp/internal/gitopsztphelper"
+	"github.com/openshift-kni/eco-gosystem/tests/gitopsztp/talm/internal/talmhelper"
+	"github.com/openshift-kni/eco-gosystem/tests/gitopsztp/talm/internal/talmparams"
 	. "github.com/openshift-kni/eco-gosystem/tests/internal/inittools"
 )
 
@@ -20,3 +26,36 @@ func TestTalm(t *testing.T) {
 
 	RunSpecs(t, "TALM Suite", reporterConfig)
 }
+
+var _ = BeforeSuite(func() {
+	err := gitopsztphelper.InitializeClients()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Make sure TALM is present
+	err = talmhelper.VerifyTalmIsInstalled()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Delete the namespace before creating it to ensure it is in a consistent blank state
+	err = talmhelper.DeleteTalmTestNamespace(true)
+	Expect(err).ToNot(HaveOccurred())
+	err = talmhelper.CreateTalmTestNamespace()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	// Deleting the namespace after the suite finishes ensures all the CGUs created are deleted
+	err := talmhelper.DeleteTalmTestNamespace(false)
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = JustAfterEach(func() {
+	reporter.ReportIfFailed(
+		CurrentSpecReport(), GeneralConfig.GetDumpFailedTestReportLocation(currentFile),
+		GeneralConfig.ReportsDirAbsPath, talmparams.ReporterNamespacesToDump,
+		talmparams.ReporterCRDsToDump, clients.SetScheme)
+})
+
+var _ = ReportAfterSuite("", func(report Report) {
+	polarion.CreateReport(
+		report, GeneralConfig.GetPolarionReportPath(), GeneralConfig.PolarionTCPrefix)
+})

--- a/tests/gitopsztp/talm/tests/talm_canary.go
+++ b/tests/gitopsztp/talm/tests/talm_canary.go
@@ -1,0 +1,57 @@
+package tests
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
+	"github.com/openshift-kni/eco-gosystem/tests/gitopsztp/talm/internal/talmhelper"
+	"github.com/openshift-kni/eco-gosystem/tests/internal/cluster"
+)
+
+var _ = Describe("Talm Canary Tests", Ordered, Label("talmcanary"), func() {
+
+	var clusterList []*clients.Settings
+
+	BeforeAll(func() {
+		// Initialize cluster list
+		clusterList = talmhelper.GetAllTestClients()
+	})
+
+	BeforeEach(func() {
+		// Check that the required clusters are present
+		err := cluster.CheckClustersPresent(clusterList)
+		if err != nil {
+			Skip(fmt.Sprintf("error occurred validating required clusters are present: %s", err.Error()))
+		}
+
+		// Cleanup state to make it consistent
+		for _, client := range clusterList {
+
+			// Cleanup everything
+			errList := talmhelper.CleanupTestResourcesOnClients(
+				[]*clients.Settings{
+					client,
+				},
+				talmhelper.CguName,
+				talmhelper.PolicyName,
+				talmhelper.Namespace,
+				talmhelper.PlacementBindingName,
+				talmhelper.PlacementRule,
+				talmhelper.PolicySetName,
+				talmhelper.CatalogSourceName)
+			Expect(errList).To(BeEmpty())
+
+			// Create namespace
+			_, err := namespace.NewBuilder(client, talmhelper.Namespace).Create()
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// Cleanup the temporary namespace
+		err = talmhelper.CleanupNamespace(clusterList, talmhelper.TemporaryNamespaceName)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+})


### PR DESCRIPTION
Add functions to talm helper.
Set talm suite.
Add first tc (canary) infra.
Due to the length and complexity of CleanupTestResourcesOnClients function, it will be added in a different PR.
