### PR TITLE
enabling sa pkg and automation strategy to add GitOps ZTP policies tests

### DIFF
--- a/tests/ranfunc/gitopsztp/tests/gitopsztp_policies_app.go
+++ b/tests/ranfunc/gitopsztp/tests/gitopsztp_policies_app.go
@@ -1,0 +1,138 @@
+package tests
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/polarion"
+	"github.com/openshift-kni/eco-goinfra/pkg/serviceaccount"
+	"github.com/openshift-kni/eco-gosystem/tests/internal/cluster"
+	"github.com/openshift-kni/eco-gosystem/tests/ranfunc/gitopsztp/internal/gitopsztphelper"
+	"github.com/openshift-kni/eco-gosystem/tests/ranfunc/gitopsztp/internal/gitopsztpparams"
+	"github.com/openshift-kni/eco-gosystem/tests/ranfunc/internal/ranfunchelper"
+	"github.com/openshift-kni/eco-gosystem/tests/ranfunc/internal/ranfuncinittools"
+	"github.com/openshift-kni/eco-gosystem/tests/ranfunc/internal/ranfuncparams"
+)
+
+var _ = Describe("ZTP Argocd policies Tests", Label("ztp-argocd-policies"), func() {
+
+	// These tests use the hub and spoke arch
+	var (
+		clusterList      []*clients.Settings
+		defaultGitRepo   = ""
+		defaultGitBranch = ""
+		defaultGitPath   = ""
+	)
+
+	BeforeAll(func() {
+		// Initialize cluster list
+		clusterList = gitopsztphelper.GetAllTestClients()
+	})
+
+	BeforeEach(func() {
+		// Check that the required clusters are present
+		err := cluster.CheckClustersPresent(clusterList)
+		if err != nil {
+			Skip(fmt.Sprintf("error occurred validating required clusters are present: %s", err.Error()))
+		}
+
+		// Check for minimum ztp version
+		By("Checking the ZTP version", func() {
+			if !ranfunchelper.IsVersionStringInRange(
+				ranfunchelper.ZtpVersion,
+				"4.10",
+				"",
+			) {
+				Skip(fmt.Sprintf(
+					"unable to run test on ztp version '%s' as it is less than minimum '%s",
+					ranfunchelper.ZtpVersion,
+					"4.10",
+				))
+			}
+		})
+
+		// Collecting and storing default Git values of policies app before the test
+		By("Collecting original Git values of policies app", func() {
+			defaultGitRepo, defaultGitBranch, defaultGitPath, err = gitopsztphelper.GetGitDetailsFromArgocd(
+				gitopsztpparams.ArgocdPoliciesAppName, ranfuncparams.OpenshiftGitops)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	AfterEach(func() {
+		// Reset the policies app back to default after each test
+		By("Resetting the policies app back to the original settings", func() {
+			err := gitopsztphelper.SetGitDetailsInArgocd(
+				defaultGitRepo, defaultGitBranch, defaultGitPath,
+				gitopsztpparams.ArgocdPoliciesAppName,
+				true,
+				false,
+			)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("Apply and Validate custom source CRs on the du policies", Label("ztp-custom-source-crs"), func() {
+
+		var (
+			// customSourceCrPolicyName = "custom-source-cr-policy-config" // enforce policy
+			testCrName       = "custom-source-cr"
+			testNs           = "default"
+			crServiceAccount = serviceaccount.NewBuilder(ranfuncinittools.SpokeAPIClient, testCrName, testNs)
+		)
+
+		It("verifies new CR kind that does not exist in ztp "+
+			"container image can be created via custom source-cr", polarion.ID("61978"), func() {
+			// The ztp test data is stored in a nested directory within the ztp repo
+			testGitPath := gitopsztphelper.JoinGitPaths(
+				[]string{
+					gitopsztphelper.ArgocdApps[gitopsztpparams.ArgocdPoliciesAppName].Path,
+					"ztp-test/custom-source-crs/new-cr",
+				},
+			)
+
+			By("Checking if the git path exists", func() {
+				if !gitopsztphelper.DoesGitPathExist(
+					gitopsztphelper.ArgocdApps[gitopsztpparams.ArgocdPoliciesAppName].Repo,
+					gitopsztphelper.ArgocdApps[gitopsztpparams.ArgocdPoliciesAppName].Branch,
+					testGitPath+"/kustomization.yaml",
+				) {
+					Skip(fmt.Sprintf("git path '%s' could not be found", testGitPath))
+				}
+			})
+
+			By("Checking Service Account custom resource does NOT exist on spoke", func() {
+				SAExists := crServiceAccount.Exists()
+				Expect(SAExists).To(BeFalse())
+			})
+
+			By("Updating the Argocd app", func() {
+				// Update the Argo app to point to the new test kustomization
+				err := gitopsztphelper.SetGitDetailsInArgocd(
+					gitopsztphelper.ArgocdApps[gitopsztpparams.ArgocdPoliciesAppName].Repo,
+					gitopsztphelper.ArgocdApps[gitopsztpparams.ArgocdPoliciesAppName].Branch,
+					testGitPath,
+					gitopsztpparams.ArgocdPoliciesAppName,
+					true,
+					true,
+				)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("Checking new Service Account custom resource created and applied to spoke", func() {
+				newCrExists := crServiceAccount.Exists()
+				Expect(newCrExists).To(BeTrue())
+			})
+		})
+
+		AfterEach(func() {
+			// Delete leftovers from the custom source-cr test
+			By("Deleting created Service Account custom resource from spoke if exists", func() {
+				err := crServiceAccount.Delete()
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+})

--- a/vendor/github.com/openshift-kni/eco-goinfra/pkg/serviceaccount/serviceaccount.go
+++ b/vendor/github.com/openshift-kni/eco-goinfra/pkg/serviceaccount/serviceaccount.go
@@ -1,0 +1,208 @@
+package serviceaccount
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/msg"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Builder provides struct for serviceaccount object containing connection to the cluster and the
+// serviceaccount definitions.
+type Builder struct {
+	// ServiceAccount definition. Used to create serviceaccount object.
+	Definition *v1.ServiceAccount
+	// Created serviceaccount object.
+	Object *v1.ServiceAccount
+	// Used in functions that defines or mutates configmap definition. errorMsg is processed before the configmap
+	// object is created.
+	errorMsg  string
+	apiClient *clients.Settings
+}
+
+// AdditionalOptions additional options for ServiceAccount object.
+type AdditionalOptions func(builder *Builder) (*Builder, error)
+
+// NewBuilder creates a new instance of Builder.
+func NewBuilder(apiClient *clients.Settings, name, nsname string) *Builder {
+	glog.V(100).Infof("Initializing new serviceaccount structure with the following params: %s, %s", name, nsname)
+
+	builder := Builder{
+		apiClient: apiClient,
+		Definition: &v1.ServiceAccount{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      name,
+				Namespace: nsname,
+			},
+		},
+	}
+
+	if name == "" {
+		glog.V(100).Infof("The name of the serviceaccount is empty")
+
+		builder.errorMsg = "serviceaccount 'name' cannot be empty"
+	}
+
+	if nsname == "" {
+		glog.V(100).Infof("The namespace of the serviceaccount is empty")
+
+		builder.errorMsg = "serviceaccount 'nsname' cannot be empty"
+	}
+
+	return &builder
+}
+
+// Pull loads an existing serviceaccount into Builder struct.
+func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
+	glog.V(100).Infof("Pulling existing serviceaccount name: %s under namespace: %s", name, nsname)
+
+	builder := Builder{
+		apiClient: apiClient,
+		Definition: &v1.ServiceAccount{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      name,
+				Namespace: nsname,
+			},
+		},
+	}
+
+	if name == "" {
+		builder.errorMsg = "serviceaccount 'name' cannot be empty"
+	}
+
+	if nsname == "" {
+		builder.errorMsg = "serviceaccount 'namespace' cannot be empty"
+	}
+
+	if !builder.Exists() {
+		return nil, fmt.Errorf("serviceaccount object %s doesn't exist in namespace %s", name, nsname)
+	}
+
+	builder.Definition = builder.Object
+
+	return &builder, nil
+}
+
+// Create makes a serviceaccount in cluster and stores the created object in struct.
+func (builder *Builder) Create() (*Builder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	glog.V(100).Infof(
+		"Creating serviceaccount %s in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	var err error
+	if !builder.Exists() {
+		builder.Object, err = builder.apiClient.ServiceAccounts(builder.Definition.Namespace).Create(
+			context.TODO(), builder.Definition, metaV1.CreateOptions{})
+	}
+
+	return builder, err
+}
+
+// Delete removes a serviceaccount.
+func (builder *Builder) Delete() error {
+	if valid, err := builder.validate(); !valid {
+		return err
+	}
+
+	glog.V(100).Infof(
+		"Deleting serviceaccount %s from namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	if !builder.Exists() {
+		return nil
+	}
+
+	err := builder.apiClient.ServiceAccounts(builder.Definition.Namespace).Delete(
+		context.TODO(), builder.Definition.Name, metaV1.DeleteOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	builder.Object = nil
+
+	return err
+}
+
+// Exists checks whether the given serviceaccount exists.
+func (builder *Builder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	glog.V(100).Infof(
+		"Checking if serviceaccount %s exists in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	var err error
+	builder.Object, err = builder.apiClient.ServiceAccounts(builder.Definition.Namespace).Get(
+		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// WithOptions creates serviceAccount with generic mutation options.
+func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Setting serviceAccount additional options")
+
+	for _, option := range options {
+		if option != nil {
+			builder, err := option(builder)
+
+			if err != nil {
+				glog.V(100).Infof("Error occurred in mutation function")
+
+				builder.errorMsg = err.Error()
+
+				return builder
+			}
+		}
+	}
+
+	return builder
+}
+
+// validate will check that the builder and builder definition are properly initialized before
+// accessing any member fields.
+func (builder *Builder) validate() (bool, error) {
+	resourceCRD := "ServiceAccount"
+
+	if builder == nil {
+		glog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		glog.V(100).Infof("The %s is undefined", resourceCRD)
+
+		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+	}
+
+	if builder.apiClient == nil {
+		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
+
+		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf(builder.errorMsg)
+	}
+
+	return true, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -423,6 +423,7 @@ github.com/openshift-kni/eco-goinfra/pkg/pod
 github.com/openshift-kni/eco-goinfra/pkg/polarion
 github.com/openshift-kni/eco-goinfra/pkg/reporter
 github.com/openshift-kni/eco-goinfra/pkg/scc
+github.com/openshift-kni/eco-goinfra/pkg/serviceaccount
 github.com/openshift-kni/eco-goinfra/pkg/sriov
 github.com/openshift-kni/eco-goinfra/pkg/statefulset
 # github.com/openshift-kni/k8sreporter v1.0.5


### PR DESCRIPTION
This PR help us to add following changes
[1] enabling service account pkg usage from eco-goinfra project and 
[2] validating test automation strategy/structure to add CNF-6925 feature GitOps ZTP tests.